### PR TITLE
Add NameServer & Fix MsgBox

### DIFF
--- a/linker.ld
+++ b/linker.ld
@@ -59,6 +59,18 @@ SECTIONS {
   .msg_demo_child_elf : {
     pie-rust/build/msg_demo_child_elf.o (.*)
   }
+  
+  . = ALIGN(0x10000); /* 2^16 = 64KB */
+  PROVIDE(name_server_elf_start = .);
+  .name_server_elf : {
+    pie-rust/build/name_server_elf.o (.*)
+  }
+
+  . = ALIGN(0x10000); /* 2^16 = 64KB */
+  PROVIDE(name_server_demo_elf_start = .);
+  .name_server_demo_elf : {
+    pie-rust/build/name_server_demo_elf.o (.*)
+  }
 
   PROVIDE(LINKER_CODE_END = .);
 }

--- a/loader/src/loader.c
+++ b/loader/src/loader.c
@@ -99,8 +99,9 @@ void load_elf(const char *args, uint64_t args_len)
   DEBUG_LOADER_PRINTF("args = %p, args_len = %llu\r\n", args, args_len);
 
   for (uint64_t i = 0; i < args_len; i += 1) {
-    if (args[i] == '\0')
+    if (args[i] == '\0') {
       DEBUG_LOADER_PRINTF(",");
+    }
     DEBUG_LOADER_PRINTF("%c", args[i]);
   }
   DEBUG_LOADER_PRINTF("\r\nargs_len = %d\r\n", args_len);
@@ -139,7 +140,7 @@ void load_elf(const char *args, uint64_t args_len)
 
   // Step 5 : Jump to function start
   EntryFunc entry_func = (EntryFunc) (elf_reader.e_hdr->e_entry + vaddr_diff);
-  printf("Step 5 : Jump to %x\r\n", entry_func);
+  printf("LOADER : Jump to %x\r\n", entry_func);
 
   // DEBUG
   // const uint32_t * peek_data = (const uint32_t *) entry_func;

--- a/loader/src/loader_args.c
+++ b/loader/src/loader_args.c
@@ -1,9 +1,12 @@
 #include "loader_priv.h"
 #include "lib/include/util.h"
+#include "lib/include/printf.h"
 
 extern char user_entry_elf_start[];
 extern char msg_demo_elf_start[];
 extern char msg_demo_child_elf_start[];
+extern char name_server_elf_start[];
+extern char name_server_demo_elf_start[];
 
 static const char * resolve_elf_start(const char * program_name) {
   if (util_strcmp(program_name, "user_entry")) {
@@ -14,6 +17,12 @@ static const char * resolve_elf_start(const char * program_name) {
   }
   if (util_strcmp(program_name, "msg_demo_child")) {
     return msg_demo_child_elf_start;
+  }
+  if (util_strcmp(program_name, "name_server")) {
+    return name_server_elf_start;
+  }
+  if (util_strcmp(program_name, "name_server_demo")) {
+    return name_server_demo_elf_start;
   }
   return NULL;
 }
@@ -29,9 +38,12 @@ struct LoaderArgs resolve_args(const char * args, uint64_t args_len)
     const char * key = &args[idx];
     uint64_t key_len = 0;
     while (key[key_len++] != '\0') {}
+    printf("LOADER_ARGS KEY = %s\r\n", key);
+
     const char * val = &args[idx + key_len];
     uint64_t val_len = 0;
     while (val[val_len++] != '\0') {}
+    printf("LOADER_ARGS VALUE = %s\r\n", val);
 
     // Check key=PROGRAM
     if (util_strcmp(key, "PROGRAM")) {

--- a/pie-rust/Cargo.toml
+++ b/pie-rust/Cargo.toml
@@ -8,7 +8,8 @@ edition = "2021"
 [dependencies]
 msgbox_macro = { path = "deps/msgbox_macro" }
 heapless = "0.8.0"
-rustc-hash = { version = "1.0", default-features = false }
+# ahash = { version = "0.8.11", default-features = false }
+fnv = { version = "1.0.7", default-features = false }
 
 [profile.dev]
 panic = "abort"
@@ -17,4 +18,3 @@ opt-level = 0
 [profile.release]
 panic = "abort"
 opt-level = 3
-debug = false

--- a/pie-rust/Cargo.toml
+++ b/pie-rust/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 msgbox_macro = { path = "deps/msgbox_macro" }
+heapless = "0.8.0"
+rustc-hash = { version = "1.0", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/pie-rust/Makefile
+++ b/pie-rust/Makefile
@@ -1,4 +1,7 @@
-all: build/user_entry_elf.o build/msg_demo_elf.o build/msg_demo_child_elf.o
+PROGRAMS=user_entry msg_demo msg_demo_child name_server name_server_demo
+PROGRAMS_ELF=$(patsubst %,build/%_elf.o,$(PROGRAMS))
+
+all: $(PROGRAMS_ELF)
 
 TARGET=aarch64-unknown-linux-gnu
 

--- a/pie-rust/src/api/mod.rs
+++ b/pie-rust/src/api/mod.rs
@@ -1,0 +1,1 @@
+pub mod name_server;

--- a/pie-rust/src/api/name_server.rs
+++ b/pie-rust/src/api/name_server.rs
@@ -1,6 +1,10 @@
 pub use msgbox_macro::*;
 pub use crate::sys::msgbox::*;
 pub use crate::sys::types::*;
+pub use crate::println;
+
+pub const NS_NAME_LIMIT : usize = 64;
+pub const NS_TID : Tid = 2;
 
 #[repr(C)]
 #[derive(Debug, Default, MsgTrait)]
@@ -11,7 +15,6 @@ pub struct NsGetReq<'a> {
 #[repr(C)]
 #[derive(Debug, Default, MsgTrait)]
 pub struct NsSetReq<'a> {
-    pub tid: Tid,
     pub name: AttachedArray<'a, u8>,
 }
 
@@ -19,4 +22,75 @@ pub struct NsSetReq<'a> {
 #[derive(Debug, Default, MsgTrait)]
 pub struct NsResp {
     pub tid: Option<Tid>,
+}
+
+#[derive(Debug, RecvEnumTrait)]
+enum NsRespRecvEnum<'a> {
+    NsResp(&'a NsResp),
+}
+
+const DEBUG : bool = true;
+const NS_SENDBOX_SZ : usize = NS_NAME_LIMIT + 64;
+const NS_RECVBOX_SZ : usize = 64;
+
+fn ns_get_loop(name: &str, wait: u32, cnt: i32) -> Option<Tid> {
+    let name_bytes = name.as_bytes();
+    let mut ns_sendbox : SendBox<NS_SENDBOX_SZ> = SendBox::default();
+    let mut ns_recvbox : RecvBox<NS_RECVBOX_SZ> = RecvBox::default();
+
+    {
+        let (mut send_ctr, get_req) = SendCtr::<NsGetReq>::new(&mut ns_sendbox).unwrap();
+        get_req.name = send_ctr.attach_array(name_bytes.len()).unwrap();
+        get_req.name.copy_from_slice(name_bytes);
+    }
+
+    let mut i = 1;
+
+    // Runs cnt time, if cnt <= 0, runs infinitely
+    loop {
+        ker_send(NS_TID, &ns_sendbox, &mut ns_recvbox).unwrap();
+
+        match NsRespRecvEnum::from_recv_bytes(&mut ns_recvbox) {
+            Some(NsRespRecvEnum::NsResp( NsResp{tid: Some(tid)} )) => { return Some(*tid); },
+            _ => (),
+        }
+
+        if cnt > 0 {
+            if i >= cnt {
+                return None;
+            }
+            i += 1;
+        }
+
+        println!("Waiting for NsGet {name}");
+
+        // wait ticks
+    }
+}
+
+pub fn ns_get(name: &str) -> Option<Tid> {
+    ns_get_loop(name, 0, 1)
+}
+
+pub fn ns_get_wait(name: &str, wait: u32) -> Tid {
+    ns_get_loop(name, wait, -1).unwrap()
+}
+
+pub fn ns_set(name: &str) -> Result<Tid, ()> {
+    let name_bytes = name.as_bytes();
+    let mut ns_sendbox : SendBox<NS_SENDBOX_SZ> = SendBox::default();
+    let mut ns_recvbox : RecvBox<NS_RECVBOX_SZ> = RecvBox::default();
+
+    {
+        let (mut send_ctr, set_req) = SendCtr::<NsSetReq>::new(&mut ns_sendbox).unwrap();
+        set_req.name = send_ctr.attach_array(name_bytes.len()).unwrap();
+        set_req.name.copy_from_slice(name_bytes);
+    } 
+
+    ker_send(NS_TID, &ns_sendbox, &mut ns_recvbox).unwrap();
+
+    match NsRespRecvEnum::from_recv_bytes(&mut ns_recvbox) {
+        Some(NsRespRecvEnum::NsResp( NsResp{tid: Some(tid)} )) => Ok(*tid),
+        _ => Err(()),
+    }
 }

--- a/pie-rust/src/api/name_server.rs
+++ b/pie-rust/src/api/name_server.rs
@@ -1,0 +1,22 @@
+pub use msgbox_macro::*;
+pub use crate::sys::msgbox::*;
+pub use crate::sys::types::*;
+
+#[repr(C)]
+#[derive(Debug, Default, MsgTrait)]
+pub struct NsGetReq<'a> {
+    pub name: AttachedArray<'a, u8>,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, MsgTrait)]
+pub struct NsSetReq<'a> {
+    pub tid: Tid,
+    pub name: AttachedArray<'a, u8>,
+}
+
+#[repr(C)]
+#[derive(Debug, Default, MsgTrait)]
+pub struct NsResp {
+    pub tid: Option<Tid>,
+}

--- a/pie-rust/src/bin/msg_demo.rs
+++ b/pie-rust/src/bin/msg_demo.rs
@@ -68,7 +68,7 @@ pub extern "C" fn _start() {
         resp.embed_field.embed = 200;
     }
 
-    ker_reply(child_tid, &send_box);
+    ker_reply(child_tid, &send_box).unwrap();
 
     /* Second Communication */
 
@@ -83,5 +83,5 @@ pub extern "C" fn _start() {
         resp.embed_field.embed = 201;
     }
 
-    ker_reply(child_tid, &send_box);
+    ker_reply(child_tid, &send_box).unwrap();
 }

--- a/pie-rust/src/bin/msg_demo_child.rs
+++ b/pie-rust/src/bin/msg_demo_child.rs
@@ -58,24 +58,24 @@ pub extern "C" fn _start() {
         let array_bytes = "array_field".as_bytes();
         let (mut send_ctr, req1) = SendCtr::<MsgDemoReq1>::new(&mut send_box).unwrap();
         req1.array_field = send_ctr.attach_array(array_bytes.len()).unwrap();
-        req1.array_field.array.copy_from_slice(array_bytes);
+        req1.array_field.copy_from_slice(array_bytes);
         req1.simple_field = 100;
     }
 
     println!("send_box\r\n{:?}", send_box.as_slice());
-    ker_send(parent_tid, &send_box, &mut recv_box);
+    ker_send(parent_tid, &send_box, &mut recv_box).unwrap();
     let recv_enum = RecvEnum::from_recv_bytes(&mut recv_box);
     println!("recv_enum\r\n{:?}", recv_enum);
 
     {
         let (mut send_ctr, req2) = SendCtr::<MsgDemoReq2>::new(&mut send_box).unwrap();
         req2.array_field = send_ctr.attach_array(2).unwrap();
-        req2.array_field.array[0].embed = 101;
-        req2.array_field.array[1].embed = 102;
+        req2.array_field[0].embed = 101;
+        req2.array_field[1].embed = 102;
     }
 
     println!("send_box\r\n{:?}", send_box.as_slice());
-    ker_send(parent_tid, &send_box, &mut recv_box);
+    ker_send(parent_tid, &send_box, &mut recv_box).unwrap();
     let recv_enum = RecvEnum::from_recv_bytes(&mut recv_box);
     println!("recv_enum\r\n{:?}", recv_enum);
 }

--- a/pie-rust/src/bin/name_server.rs
+++ b/pie-rust/src/bin/name_server.rs
@@ -1,0 +1,134 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+use core::hash::{Hash, Hasher};
+
+use rust_pie::println;
+use rust_pie::api::name_server::*;
+
+use heapless::FnvIndexMap;
+use fnv::FnvHasher;
+
+/// This function is called on panic.
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    println!("{}", info);
+    loop {}
+}
+
+const DEBUG: bool = false;
+const MAP_CAP : usize = 128;
+type NameMap = FnvIndexMap::<u64, Tid, MAP_CAP>;
+
+#[derive(Debug, RecvEnumTrait)]
+enum RecvEnum<'a> {
+    NsGetReq(&'a mut NsGetReq<'a>),
+    NsSetReq(&'a mut NsSetReq<'a>),
+}
+
+/* Entry Function */
+
+#[no_mangle]
+pub extern "C" fn _start() {
+    let mut name_map = NameMap::new();
+
+    let mut send_box: SendBox = SendBox::default();
+    let mut recv_box: RecvBox = RecvBox::default();
+    
+    loop {
+        let sender_tid = ker_recv(&mut recv_box);
+
+        if DEBUG {
+            println!("Name Server : ker_recv {}", sender_tid);
+            println!("{:?}", &recv_box.recv_buf[0..32]);
+            println!("{:?}", &recv_box.recv_buf[32..64]);
+        }
+
+        let (_send_ctr, ns_resp) = SendCtr::<NsResp>::new(&mut send_box).unwrap();
+
+        ns_resp.tid = match RecvEnum::from_recv_bytes(&mut recv_box) {
+            Some(RecvEnum::NsGetReq(get_req)) => handle_get_req(&mut name_map, get_req),
+            Some(RecvEnum::NsSetReq(set_req)) => handle_set_req(&mut name_map, set_req, sender_tid),
+            None => { println!("Name Server : Received None !"); None },
+        };
+
+        if DEBUG {
+            println!("Name Server : ker_reply {} {:?}", sender_tid, ns_resp.tid);
+        }
+        ker_reply(sender_tid, &send_box).unwrap();
+    }
+}
+
+fn calc_hash_u8_slice(t: &[u8]) -> u64 {
+    if DEBUG {
+        println!("calc_hash_u8_slice : Start");
+    }
+    let mut s = FnvHasher::default();
+    if DEBUG {
+        println!("calc_hash_u8_slice : Default Hasher");
+    }
+    u8::hash_slice(t, &mut s);
+    if DEBUG {
+        println!("calc_hash_u8_slice : Hash Slice");
+    }
+    s.finish()
+}
+
+fn handle_get_req(name_map: &mut NameMap, get_req: &mut NsGetReq) -> Option<Tid> {
+    if DEBUG {
+        println!("Name Server : handle_get_req");
+    }
+
+    let array_bytes : &[u8] = &get_req.name;
+
+    if DEBUG {
+        println!("Name Server : array_bytes {:?}", array_bytes);
+    }
+
+    let hash_result : u64 = calc_hash_u8_slice(array_bytes);
+
+    if DEBUG {
+        println!("Name Server : name_map.get {hash_result}");
+    }
+
+    if let Some(tid) = name_map.get(&hash_result) {
+        if *tid > 0 {
+            return Some(*tid);
+        }
+    }
+
+    return None;
+}
+
+fn handle_set_req(name_map: &mut NameMap, set_req: &mut NsSetReq, sender_tid: Tid) -> Option<Tid> {
+    if DEBUG {
+        println!("Name Server : handle_set_req");
+    }
+
+    let array_bytes : &[u8] = &set_req.name;
+
+    if DEBUG {
+        println!("Name Server : array_bytes {:?}", array_bytes);
+    }
+
+    let hash_result : u64 = calc_hash_u8_slice(array_bytes);
+
+    if DEBUG {
+        println!("Name Server : name_map.get {hash_result}");
+    }
+
+    if let Some(_tid) = name_map.get(&hash_result) {
+        if DEBUG {
+            println!("Name Server : Hash Collision Detected for {:?} !!!", array_bytes);
+        }
+        return None;
+    }
+
+    if DEBUG {
+        println!("Name Server : name_map.insert {hash_result}");
+    }
+
+    name_map.insert(hash_result, sender_tid).unwrap();
+    return Some(sender_tid);
+}

--- a/pie-rust/src/bin/name_server_demo.rs
+++ b/pie-rust/src/bin/name_server_demo.rs
@@ -1,0 +1,23 @@
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+use rust_pie::sys::syscall::*;
+use rust_pie::api::name_server::*;
+use rust_pie::println;
+
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    println!("{}", info);
+    loop {}
+}
+
+#[no_mangle]
+pub extern "C" fn _start() {
+    let my_tid = ker_my_tid();
+    println!("Name Server Demo : NsSet {:?}", my_tid);
+    ns_set("name_server_demo").unwrap();
+    let ret = ns_get("name_server_demo");
+    println!("Name Server Demo : NsGet {:?}", ret);
+}

--- a/pie-rust/src/bin/user_entry.rs
+++ b/pie-rust/src/bin/user_entry.rs
@@ -19,7 +19,7 @@ pub extern "C" fn _start() {
 
     rust_pie::sys::print_raw::ker_print_raw(msg1);
 
-    let child_args = "PROGRAM\0msg_demo\0".as_bytes();
+    let child_args = "PROGRAM\0name_server_demo\0".as_bytes();
     let child_tid = ker_create(1, child_args).unwrap();
     println!("child_tid = {child_tid}");
 

--- a/pie-rust/src/lib.rs
+++ b/pie-rust/src/lib.rs
@@ -4,3 +4,4 @@
 #![feature(c_size_t)]
 
 pub mod sys;
+pub mod api;

--- a/pie-rust/src/sys/syscall.rs
+++ b/pie-rust/src/sys/syscall.rs
@@ -5,6 +5,7 @@ use crate::sys::types::Tid;
 extern "C" {
     fn ke_create(priority: c_int, args: *const c_char, args_len: c_size_t) -> c_int;
     fn ke_my_parent_tid() -> c_int;
+    fn ke_my_tid() -> c_int;
 }
 
 pub fn ker_create(priority: i32, args: &[u8]) -> Result<Tid, i32> {
@@ -25,5 +26,10 @@ pub fn ker_create(priority: i32, args: &[u8]) -> Result<Tid, i32> {
 pub fn ker_parent_tid() -> Tid {
     unsafe {
         ke_my_parent_tid() as Tid
+    }
+}
+pub fn ker_my_tid() -> Tid {
+    unsafe {
+        ke_my_tid() as Tid
     }
 }


### PR DESCRIPTION
NameServer maintains a table of string → Tid.
NameServer provide get and set methods: NsSet, NsGet.
NameServer is a system task.
NameServer is created by kernel main.

Currently NameServer simply uses a hash function and fails on hash collision.
Method to resolve hash collision will be created when required later.

This PR also fixes some bugs on MsgBox.